### PR TITLE
Fix unicode path and filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "Static File Web Server",
     "uri": "gh:zedapp/staticserver",
-    "version": "0.1",
+    "version": "0.2",
     "description": "Static file serving embedded in Zed",
     "files": [
         "server.js",


### PR DESCRIPTION
staticserver currently doesn't handle unicode filename or filename with special characters correctly.

I add a `StringToBinary` function in server.js,
maybe this should be in `js/fs/util.js` of main zed repository?
other users may also need convert JavaScript string to binary string.
